### PR TITLE
Add relative imports for easier installation and imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ python -m venv .venv
 source .venv/bin/activate
 
 # Install dependencies
-pip install -r requirements.txt
+pip install --editable .
 ```
 For optimal inference speed, it's recommended to install [xformers](https://github.com/facebookresearch/xformers?tab=readme-ov-file#installing-xformers) and [flash-attention](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file#installation-and-features) as well.
 
@@ -69,9 +69,9 @@ Here's a simple example to get you started with forecasting:
 
 ```python
 import torch
-from data.util.dataset import MaskedTimeseries
-from inference.forecaster import TotoForecaster
-from model.toto import Toto
+from toto.data.util.dataset import MaskedTimeseries
+from toto.inference.forecaster import TotoForecaster
+from toto.model.toto import Toto
 
 # Load the pre-trained model
 toto = Toto.from_pretrained('Datadog/Toto-Open-Base-1.0')

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd toto
 python -m venv .venv
 source .venv/bin/activate
 
-# Install dependencies
+# Install package
 pip install --editable .
 ```
 For optimal inference speed, it's recommended to install [xformers](https://github.com/facebookresearch/xformers?tab=readme-ov-file#installing-xformers) and [flash-attention](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file#installation-and-features) as well.

--- a/toto/inference/forecaster.py
+++ b/toto/inference/forecaster.py
@@ -13,13 +13,13 @@ from gluonts.torch.distributions import AffineTransformed
 from jaxtyping import Bool, Float, Int
 from torch.distributions import Distribution
 
-from data.util.dataset import (
+from ..data.util.dataset import (
     MaskedTimeseries,
     pad_array,
     pad_id_mask,
     replace_extreme_values,
 )
-from model.backbone import TotoBackbone
+from ..model.backbone import TotoBackbone
 
 
 @dataclass(frozen=True)

--- a/toto/model/attention.py
+++ b/toto/model/attention.py
@@ -11,10 +11,10 @@ import torch
 from einops import rearrange
 from jaxtyping import Bool, Float, Int
 
-from model.rope import TimeAwareRotaryEmbedding
+from ..model.rope import TimeAwareRotaryEmbedding
 
 if TYPE_CHECKING:
-    from model.util import KVCache  # Import only for type checking
+    from ..model.util import KVCache  # Import only for type checking
 
 
 try:

--- a/toto/model/backbone.py
+++ b/toto/model/backbone.py
@@ -10,11 +10,11 @@ import torch
 from einops import rearrange
 from jaxtyping import Bool, Float, Int
 
-from model.distribution import DISTRIBUTION_CLASSES_LOOKUP, DistributionOutput
-from model.embedding import PatchEmbedding
-from model.scaler import scaler_types
-from model.transformer import Transformer
-from model.util import KVCache
+from ..model.distribution import DISTRIBUTION_CLASSES_LOOKUP, DistributionOutput
+from ..model.embedding import PatchEmbedding
+from ..model.scaler import scaler_types
+from ..model.transformer import Transformer
+from ..model.util import KVCache
 
 
 class TotoOutput(NamedTuple):

--- a/toto/model/toto.py
+++ b/toto/model/toto.py
@@ -13,9 +13,9 @@ import safetensors.torch as safetorch
 import torch
 from huggingface_hub import ModelHubMixin, constants, hf_hub_download
 
-from model.attention import XFORMERS_AVAILABLE
-from model.backbone import TotoBackbone
-from model.transformer import XFORMERS_SWIGLU_AVAILABLE
+from ..model.attention import XFORMERS_AVAILABLE
+from ..model.backbone import TotoBackbone
+from ..model.transformer import XFORMERS_SWIGLU_AVAILABLE
 
 
 class Toto(torch.nn.Module, ModelHubMixin):

--- a/toto/model/transformer.py
+++ b/toto/model/transformer.py
@@ -12,15 +12,15 @@ from einops import rearrange
 from jaxtyping import Bool, Float, Int
 from rotary_embedding_torch import RotaryEmbedding
 
-from model.attention import (
+from ..model.attention import (
     AttentionAxis,
     MultiHeadAttention,
     SpaceWiseMultiheadAttention,
     TimeWiseMultiheadAttention,
 )
-from model.feed_forward import SwiGLU
-from model.rope import TimeAwareRotaryEmbedding
-from model.util import KVCache, RMSNorm, make_batched_block_mask
+from ..model.feed_forward import SwiGLU
+from ..model.rope import TimeAwareRotaryEmbedding
+from ..model.util import KVCache, RMSNorm, make_batched_block_mask
 
 try:
     from xformers.ops.swiglu_op import SwiGLU as SwiGLU_fused

--- a/toto/model/util.py
+++ b/toto/model/util.py
@@ -11,10 +11,10 @@ import torch
 from einops import rearrange
 from jaxtyping import Float, Int
 
-from model.attention import TimeWiseMultiheadAttention
+from ..model.attention import TimeWiseMultiheadAttention
 
 if TYPE_CHECKING:
-    from model.transformer import TransformerLayer  # Import only for type checking
+    from ..model.transformer import TransformerLayer  # Import only for type checking
 
 try:
     from xformers import _is_triton_available


### PR DESCRIPTION
Great work, Toto team! 

Currently, the package structure and the way things are imported prevent easy installation and imports without python path hacks. This PR is a PoC which would fix these issues. With the fixes in this PR, one can easily install package using pip and the imports work as expected. Please note that I have not fixed imports everywhere and tested everything, e.g., some notebooks probably still work in the old way by appending to python path. However, most of these things can be easily fixed by removing the path hacks and prefixing `toto.` in imports. Please feel free to either update this PR with these fixes or create a separate PR based on this one. 

Cheers!