### PR TITLE
Add item_id in TotoSampleForecast

### DIFF
--- a/toto/inference/gluonts_predictor.py
+++ b/toto/inference/gluonts_predictor.py
@@ -188,7 +188,7 @@ class TotoSampleForecastGenerator(SampleForecastGenerator):
                     samples=samples[item_idx],
                     mean=avg[item_idx],
                     start_date=batch["forecast_start"][item_idx],
-                    item_id=None,
+                    item_id=batch['item_id'][item_idx],
                     info=None,
                 )
 

--- a/toto/inference/gluonts_predictor.py
+++ b/toto/inference/gluonts_predictor.py
@@ -188,7 +188,7 @@ class TotoSampleForecastGenerator(SampleForecastGenerator):
                     samples=samples[item_idx],
                     mean=avg[item_idx],
                     start_date=batch["forecast_start"][item_idx],
-                    item_id=batch['item_id'][item_idx],
+                    item_id=batch["item_id"][item_idx],
                     info=None,
                 )
 


### PR DESCRIPTION
Although the default behavior is to iterate through the test set in a fixed order, add item_id in TotoSampleForecast can reduce error risk