### PR TITLE
Adding build system configs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "toto-ts"
 version = "0.1.0"
+description = "Time-Series-Optimized Transformer for Observability"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "DataDog, Inc."}
+]
 dynamic = ["dependencies"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Adds a build system config to enable creating metadata when publishing to pypi