### PR TITLE
[AITP-23] Upgrade GitHub actions version

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -57,6 +57,6 @@ jobs:
           path: dist/
           
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # release/v1
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.12.2
         with:
           packages-dir: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "toto-ts"
-version = "0.1.1"
+version = "0.1.2"
 description = "Time-Series-Optimized Transformer for Observability"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Upgrade github actions version to enable publishing to pypi with a supported metadata version