### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "toto-ts"
-version = "0.1.4"
+version = "0.2.0"
 description = "Time-Series-Optimized Transformer for Observability"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump package version from 0.1.4 to 0.2.0 for the fine-tuning and exogenous variables release.

### Changes
- `pyproject.toml`: version 0.1.4 → 0.2.0

### Release Notes
After merging, create a GitHub release with tag `v0.2.0` to trigger PyPI publishing.
