### PR TITLE
Bump toto-2 to 2.0.0 for Toto 2.0 release

### DIFF
--- a/toto2/pyproject.toml
+++ b/toto2/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "toto-2"
-version = "0.2.0"
+version = "2.0.0"
 description = "Toto 2.0"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Align the new `toto-2` package version with the [Toto 2.0 release](https://www.datadoghq.com/blog/ai/toto-2/) so GitHub releases, PyPI installs, and citations line up with the marketing name.

- `toto2/pyproject.toml` (`toto-2`): `0.2.0` → `2.0.0`

`toto-ts` (the Toto 1.0 package at the repo root) intentionally stays at `0.2.0`. Toto 2.0 ships as a **separate `toto-2` package**, not as a new version of `toto-ts`. Bumping `toto-ts` would:
- falsely imply that `pip install toto-ts==2.0.0` installs Toto 2.0 (it doesn't — that package still ships the 1.0 model + fine-tuning code),
- gratuitously break `toto-ts>=0.1,<1` style pins on existing 1.0 users.

The Toto 2.0 code (inference package, block decoding, imputation, quantile capping, refreshed BOOM leaderboards) has already landed on `main`; this PR just bumps the new package's version so we can cut a formal `toto-2/v2.0.0` GitHub release / PyPI publish on top of it.