### PR TITLE
Bump toto-ts package version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "toto-ts"
-version = "0.2.0"
+version = "2.0.0"
 description = "Time-Series-Optimized Transformer for Observability"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Problem

The `v2.0.0` GitHub release was cut, but `pyproject.toml` was never updated from `version = "0.2.0"`. The `pypi-publish` workflow built `toto_ts-0.2.0-py3-none-any.whl` and hit a `400 Bad Request` from PyPI because `0.2.0` already exists — so `v2.0.0` was never published. Downloads dropped to 0 on Hugging Face as a result.

## Fix

Bump `version` in root `pyproject.toml` from `0.2.0` → `2.0.0`.

## Next step after merging

Delete and re-create the `v2.0.0` release/tag to re-trigger the `pypi-publish` workflow with the correct version baked into the build artifact.