### PR TITLE
Fix pypi-publish workflow to publish toto-2 from toto2/ subdirectory

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,5 +1,5 @@
-# This workflow will upload the Toto Python Package to PyPI when a release is created
-name: Upload Toto Package to PyPI
+# Publishes toto-2 to PyPI when a release with a tag starting with 'toto-2/' is published (e.g. toto-2/v2.0.0)
+name: Upload toto-2 to PyPI
 
 on:
   release:
@@ -11,26 +11,23 @@ permissions:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'toto-2/')
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
-          python-version: "3.10"  
-          
+          python-version: "3.12"
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install build wheel setuptools
-          
-      - name: Install package dependencies
-        run: |
-          pip install -r requirements.txt
-          
+
       - name: Build release distributions
         run: |
-          python -m build
-          
+          python -m build toto2/ --outdir dist/
+
       - name: Upload distributions
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -39,23 +36,21 @@ jobs:
 
   pypi-publish:
     runs-on: ubuntu-latest
-    needs:
-      - release-build
+    needs: release-build
+    if: startsWith(github.ref_name, 'toto-2/')
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     environment:
       name: pypi
-      # PyPI project URL for toto package
-      url: https://pypi.org/project/toto-ts/${{ github.event.release.name }}
-      
+      url: https://pypi.org/project/toto-2/${{ github.event.release.tag_name }}
+
     steps:
-      - name: Retrieve release distributions  
+      - name: Retrieve release distributions
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: release-dists
           path: dist/
-          
+
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:


### PR DESCRIPTION
## Problem

The `v2.0.0` release was cut for Toto 2.0, but `toto-2` has never been published to PyPI — it doesn't exist there at all. The `pypi-publish` workflow was building from the repo root, which produces `toto_ts-0.2.0.whl` (the legacy Toto 1.0 package). That upload failed with a 400 because `toto-ts 0.2.0` already exists on PyPI.

Per PR #110, `toto-ts` intentionally stays at `0.2.0` — Toto 2.0 ships as the separate `toto-2` package. The workflow just never got updated to reflect this.

## Fix

- Change build source from repo root → `toto2/` subdirectory: `python -m build toto2/ --outdir dist/`
- Update Python version to 3.12 (required by `toto2/pyproject.toml`)
- Update environment URL to point to `toto-2` on PyPI

## After merging

Delete and re-create the `v2.0.0` release/tag to re-trigger this workflow and publish `toto-2==2.0.0` to PyPI.

Note: this workflow now only handles `toto-2` releases. If `toto-ts` ever needs a new release, a separate workflow will be needed.