### PR TITLE
Add toto-models wrapper package

### DIFF
--- a/.github/workflows/pypi-publish-dd-unit-scaling.yml
+++ b/.github/workflows/pypi-publish-dd-unit-scaling.yml
@@ -1,0 +1,57 @@
+# Publishes dd-unit-scaling to PyPI when a release with a tag starting with 'dd-unit-scaling/' is published
+name: Upload dd-unit-scaling to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'dd-unit-scaling/')
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build wheel setuptools
+
+      - name: Build release distributions
+        run: |
+          python -m build dd_unit_scaling/ --outdir dist/
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs: release-build
+    if: startsWith(github.ref_name, 'dd-unit-scaling/')
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/dd-unit-scaling/${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          packages-dir: dist/

--- a/.github/workflows/pypi-publish-toto-models.yml
+++ b/.github/workflows/pypi-publish-toto-models.yml
@@ -1,0 +1,57 @@
+# Publishes toto-models to PyPI when a release with a tag starting with 'toto-models/' is published
+name: Upload toto-models to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'toto-models/')
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build wheel setuptools
+
+      - name: Build release distributions
+        run: |
+          python -m build toto_models/ --outdir dist/
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs: release-build
+    if: startsWith(github.ref_name, 'toto-models/')
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/toto-models/${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          packages-dir: dist/

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Toto 2.0 is the latest generation, featuring a u-μP-scaled transformer with alt
 ### Installation
 
 ```bash
-pip install "toto-2 @ git+https://github.com/DataDog/toto.git#subdirectory=toto2"
+pip install toto-models
 ```
 
 ### Quick Start
@@ -105,7 +105,7 @@ quantiles = model.forecast(
 
 ### Requirements
 
-- Python 3.10+
+- Python 3.12+
 - PyTorch 2.5+
 - CUDA-capable device (Ampere generation or newer recommended for optimal performance)
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Toto 2.0 is the latest generation, featuring a u-μP-scaled transformer with alt
 
 ### Installation
 
+Install Toto 2.0 (requires Python 3.12+):
+
 ```bash
 pip install toto-models
 ```

--- a/dd_unit_scaling/README.md
+++ b/dd_unit_scaling/README.md
@@ -15,7 +15,7 @@ The upstream `unit_scaling` library implements u-μP correctly in principle, but
 ## Installation
 
 ```bash
-pip install "dd-unit-scaling @ git+https://github.com/DataDog/toto.git#subdirectory=dd_unit_scaling"
+pip install dd-unit-scaling
 ```
 
 For Muon-family optimizers, also install [dion](https://github.com/microsoft/dion):

--- a/toto2/notebooks/gluonts_integration.ipynb
+++ b/toto2/notebooks/gluonts_integration.ipynb
@@ -23,7 +23,7 @@
     "## Installation\n",
     "\n",
     "```bash\n",
-    "pip install \"toto-2 @ git+https://github.com/DataDog/toto.git#subdirectory=toto2\"\n",
+    "pip install toto-models\n",
     "```"
    ]
   },

--- a/toto2/notebooks/quick_start.ipynb
+++ b/toto2/notebooks/quick_start.ipynb
@@ -26,7 +26,7 @@
     "## Installation\n",
     "\n",
     "```bash\n",
-    "pip install \"toto-2 @ git+https://github.com/DataDog/toto.git#subdirectory=toto2\"\n",
+    "pip install toto-models\n",
     "```\n",
     "\n",
     "This also installs `dd-unit-scaling` and all other dependencies automatically."

--- a/toto2/pyproject.toml
+++ b/toto2/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "huggingface-hub>=0.20.0",
     "safetensors>=0.4.0",
     "jaxtyping>=0.2.25",
-    "dd-unit-scaling @ git+https://github.com/DataDog/toto.git#subdirectory=dd_unit_scaling",
+    "dd-unit-scaling>=0.1.0",
     "matplotlib>=3.9.0",
 ]
 

--- a/toto_models/pyproject.toml
+++ b/toto_models/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "toto-models"
+version = "1.0.0"
+description = "Umbrella package for Datadog Toto time series models"
+requires-python = ">=3.12"
+license = {text = "Apache-2.0"}
+authors = [{name = "DataDog, Inc."}]
+dependencies = ["toto-2>=2.0.0"]
+
+[project.optional-dependencies]
+v1 = ["toto-ts>=0.2.0"]
+
+[tool.setuptools.packages.find]
+include = ["toto_models*"]


### PR DESCRIPTION
## What this does

Adds a `toto-models` umbrella package and a `dd-unit-scaling` PyPI publish workflow so all Toto dependencies are installable without git access (e.g. Ray clusters):

```bash
pip install toto-models    # installs toto-2 (and dd-unit-scaling transitively)
```

## Files added / changed

- `toto_models/pyproject.toml` — umbrella package (`toto-2` as base dep, `toto-ts` as optional `[v1]` extra)
- `toto_models/toto_models/__init__.py` — empty, required for setuptools to find the package
- `.github/workflows/pypi-publish-toto-models.yml` — publishes `toto-models` on `toto-models/*` tags
- `.github/workflows/pypi-publish-dd-unit-scaling.yml` — publishes `dd-unit-scaling` on `dd-unit-scaling/*` tags
- `toto2/pyproject.toml` — replace `git+https` dd-unit-scaling dep with PyPI version (`>=0.1.0`)
- `README.md` — update install to `pip install toto-models`, fix Python requirement 3.10+ → 3.12+
- `dd_unit_scaling/README.md` — update install to `pip install dd-unit-scaling`
- `toto2/notebooks/` — update install instructions to `pip install toto-models`

## Pre-requisites before merging

1. Merge PR #115 first (publishes `toto-2` to PyPI)
2. Register all three new packages on PyPI via `#pypi-admin` with trusted publishing:
   - `toto-models`: Repo `DataDog/toto`, Workflow `pypi-publish-toto-models.yml`, Environment `pypi`
   - `dd-unit-scaling`: Repo `DataDog/toto`, Workflow `pypi-publish-dd-unit-scaling.yml`, Environment `pypi`

## After merging

Cut releases in this order (dd-unit-scaling first since toto-2 depends on it):
1. Tag `dd-unit-scaling/v0.1.0` → publishes `dd-unit-scaling==0.1.0`
2. Tag `toto-2/v2.0.0` → publishes `toto-2==2.0.0`
3. Tag `toto-models/v1.0.0` → publishes `toto-models==1.0.0`