### PR TITLE
Add PyPI compliance metadata to all four publishable packages

### DIFF
--- a/dd_unit_scaling/pyproject.toml
+++ b/dd_unit_scaling/pyproject.toml
@@ -8,10 +8,19 @@ version = "0.1.0"
 description = "Compile-friendly, world-size-aware unit scaling"
 readme = "README.md"
 requires-python = ">=3.12"
+license = {text = "Apache-2.0"}
+authors = [{name = "DataDog, Inc.", email = "package@datadoghq.com"}]
+keywords = ["unit-scaling", "distributed-training", "pytorch", "datadog"]
 dependencies = [
     "torch>=2.4.0",
     "unit-scaling>=0.2.0",
 ]
+
+[project.urls]
+Homepage = "https://www.datadoghq.com"
+Repository = "https://github.com/DataDog/toto/tree/main/dd_unit_scaling"
+"Bug Tracker" = "https://github.com/DataDog/toto/issues"
+Changelog = "https://github.com/DataDog/toto/releases"
 
 [project.optional-dependencies]
 optim = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,16 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [
-    {name = "DataDog, Inc."}
+    {name = "DataDog, Inc.", email = "package@datadoghq.com"}
 ]
+keywords = ["time-series", "forecasting", "transformer", "observability", "datadog"]
 dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://www.datadoghq.com"
+Repository = "https://github.com/DataDog/toto"
+"Bug Tracker" = "https://github.com/DataDog/toto/issues"
+Changelog = "https://github.com/DataDog/toto/releases"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/toto2/pyproject.toml
+++ b/toto2/pyproject.toml
@@ -10,8 +10,9 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
 authors = [
-    {name = "DataDog, Inc."}
+    {name = "DataDog, Inc.", email = "package@datadoghq.com"}
 ]
+keywords = ["time-series", "forecasting", "transformer", "foundation-model", "multivariate", "datadog"]
 dependencies = [
     "torch>=2.4.0",
     "einops>=0.7.0",
@@ -23,6 +24,12 @@ dependencies = [
     "dd-unit-scaling>=0.1.0",
     "matplotlib>=3.9.0",
 ]
+
+[project.urls]
+Homepage = "https://www.datadoghq.com"
+Repository = "https://github.com/DataDog/toto/tree/main/toto2"
+"Bug Tracker" = "https://github.com/DataDog/toto/issues"
+Changelog = "https://github.com/DataDog/toto/releases"
 
 [project.optional-dependencies]
 dev = [

--- a/toto_models/pyproject.toml
+++ b/toto_models/pyproject.toml
@@ -9,8 +9,15 @@ description = "Umbrella package for Datadog Toto time series models"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "Apache-2.0"}
-authors = [{name = "DataDog, Inc."}]
+authors = [{name = "DataDog, Inc.", email = "package@datadoghq.com"}]
+keywords = ["time-series", "forecasting", "datadog", "toto", "models"]
 dependencies = ["toto-2>=2.0.0"]
+
+[project.urls]
+Homepage = "https://www.datadoghq.com"
+Repository = "https://github.com/DataDog/toto/tree/main/toto_models"
+"Bug Tracker" = "https://github.com/DataDog/toto/issues"
+Changelog = "https://github.com/DataDog/toto/releases"
 
 [project.optional-dependencies]
 v1 = ["toto-ts>=0.2.0"]


### PR DESCRIPTION
## Summary
Small compliance and metadata fixes applied independently to each of the four
publishable Python packages in this monorepo (`toto-ts` at the repo root;
`toto-2`, `toto-models`, and `dd-unit-scaling` in subdirectories). No runtime,
API, build-backend, or publishing-mechanism changes.

## Changes
### `pyproject.toml` (toto-ts, repo root)
- Add `package@datadoghq.com` to `authors`.
- Add `keywords` for discoverability.
- Add `[project.urls]` with `Homepage`, `Repository` (repo root), `Bug Tracker`,
  and `Changelog`.

### `toto2/pyproject.toml` (toto-2)
- Add `package@datadoghq.com` to `authors`.
- Add `keywords`.
- Add `[project.urls]`; `Repository` points to `…/tree/main/toto2`.

### `toto_models/pyproject.toml` (toto-models)
- Add `package@datadoghq.com` to `authors`.
- Add `keywords`.
- Add `[project.urls]`; `Repository` points to `…/tree/main/toto_models`.

### `dd_unit_scaling/pyproject.toml` (dd-unit-scaling)
- Add missing `license = {text = "Apache-2.0"}`.
- Add missing `authors` (with `package@datadoghq.com`).
- Add `keywords`.
- Add `[project.urls]`; `Repository` points to `…/tree/main/dd_unit_scaling`.

## Testing
Metadata-only change. Validated each `pyproject.toml` parses with Python's
`tomllib` and that the `[project.urls]` keys render as expected. Verified each
subdirectory package's `readme = "README.md"` resolves within its own build
context (`python -m build <subdir>`).
