### PR TITLE
Remove unsupported dd-unit-scaling optim extra

### DIFF
--- a/dd_unit_scaling/pyproject.toml
+++ b/dd_unit_scaling/pyproject.toml
@@ -4,18 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dd-unit-scaling"
-version = "0.1.0"
+version = "0.1.1"
 description = "Compile-friendly, world-size-aware unit scaling"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "torch>=2.4.0",
     "unit-scaling>=0.2.0",
-]
-
-[project.optional-dependencies]
-optim = [
-    "dion",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

- remove the undocumented and unsupported `optim` extra from `dd-unit-scaling`
- bump the package to `0.1.1` so corrected metadata can be published

## Context

The documented installation path is to install `dd-unit-scaling` normally and install Microsoft Dion directly from its GitHub repository. We do not document or support `pip install "dd-unit-scaling[optim]"`, and the packages in this repository depend only on base `dd-unit-scaling`.

This change hardens that unsupported path by removing metadata that would otherwise cause someone who independently chose `[optim]` to resolve the bare `dion` name from PyPI. It does not change the documented installation flow.

## Testing

Built the `0.1.1` sdist and wheel in a clean Python 3.12 container and verified that the wheel has no `Requires-Dist: dion` metadata.

## Release follow-up

After merge, publish `dd-unit-scaling/v0.1.1`. Consider yanking `0.1.0` after the corrected release is available.